### PR TITLE
FIxed audio send and received buffers config

### DIFF
--- a/example-audio-receiver/src/ofApp.cpp
+++ b/example-audio-receiver/src/ofApp.cpp
@@ -21,8 +21,8 @@ void ofApp::setup(){
 	std::string name_or_url = "";	// Specify name or address of expected NDI source. In case of blank or not found, receiver will grab default(which is found first) source.
 	auto result = findSource(name_or_url);
 	if(result.second ? receiver_.setup(result.first) : receiver_.setup()) {
-		int sample_rate = 44100;
-		int num_channels = 1;
+		int sample_rate = 48000;
+		int num_channels = 2;
 		int num_buffers = 1;
 		int num_samples = 512;
 		audio_.setup(receiver_);

--- a/example-audio-sender/src/ofApp.cpp
+++ b/example-audio-sender/src/ofApp.cpp
@@ -9,7 +9,7 @@ void ofApp::setup(){
 		ofLogError("NDI setup failed.");
 	}
 	ofSoundStreamSettings sss;
-	sss.numInputChannels = 1;
+	sss.numInputChannels = 2;
 	sss.numOutputChannels = 0;
 	sss.sampleRate = 48000;
 	sss.numBuffers = 1;


### PR DESCRIPTION
Hi, I found out that the addon was not handling multi channel audio in the correct way, so I made the fix in this PR.
NDI uses planar sound buffers, this means that each channel is saved sequentially instead of OF which uses interleaved sound buffers.
I've tested it and works as expected.